### PR TITLE
Updating common Error to follow convention in Videa API guidelines

### DIFF
--- a/endpoints/schemas/commonSchemas.yaml
+++ b/endpoints/schemas/commonSchemas.yaml
@@ -558,14 +558,17 @@ components:
 
     Error:
       required:
-        - errorCode
-        - errorMessage
+        - code
+        - message
       properties:
-        errorCode:
-          type: integer
-          format: int32
-        errorMessage:
+        code:
           type: string
+        message:
+          type: string
+        target:
+          type: string
+        details:
+          type: object
 
     acceptedResponse:
       required:


### PR DESCRIPTION
Updating common Error to follow convention in Videa API guidelines

Versioning: 

https://github.com/videa-tv/api-guidelines/blob/vNext/Guidelines.md#121-versioning-formats

Error:

https://github.com/videa-tv/api-guidelines/blob/vNext/Guidelines.md#error--object